### PR TITLE
File extension validation

### DIFF
--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk';
 import glob from 'glob';
+import slash from 'slash';
 import { readFileSync } from 'fs';
 import { isBinaryFileSync } from 'isbinaryfile';
 import { program } from 'commander';
 import { TrayApi } from '../api/v1/TrayApi';
-import { loadConfigFile, logMessage } from '../libs/utils';
+import { loadConfigFile, logMessage, checkFileUploadPermission, prepareToUpload } from '../libs/utils';
 
 /**
  * Upload one or more files for theme
@@ -36,27 +37,38 @@ export function upload() {
             let successAssets = 0;
             let errorAssets = 0;
 
-            for (const asset of assets) {
-                logMessage('pending', `Uploading file ${chalk.magenta(asset)}...`);
+            for (const path of assets) {
+                const asset = slash(path);
 
-                const assetStartingWithSlash = asset.startsWith('/') ? asset : `/${asset}`;
+                const isAllowed = checkFileUploadPermission(asset);
 
-                const fileContent = readFileSync(`.${assetStartingWithSlash}`);
-                const isBinary = isBinaryFileSync(`.${assetStartingWithSlash}`);
+                if ( isAllowed ) {
+                    logMessage('pending', `Uploading file ${chalk.magenta(asset)}...`);
 
-                // eslint-disable-next-line no-await-in-loop
-                const sendFileResult: any = await api.sendThemeAsset(assetStartingWithSlash, fileContent, isBinary);
-
-                if (!sendFileResult.success) {
+                    const {
+                        assetStartingWithSlash,
+                        fileContent,
+                        isBinary
+                    } = prepareToUpload(asset);
+                    
+                    // eslint-disable-next-line no-await-in-loop
+                    const sendFileResult: any = await api.sendThemeAsset(assetStartingWithSlash, fileContent, isBinary);
+                    
+                    if (!sendFileResult.success) {
+                        errorAssets++;
+                        logMessage(
+                            'error',
+                            `Error when uploading file ${chalk.magenta(asset)}. Error: ${sendFileResult.message}`,
+                            true
+                        );
+                    } else {
+                        successAssets++;
+                        logMessage('success', `File ${chalk.magenta(asset)} uploaded.`, true);
+                    }
+                }
+                else {
                     errorAssets++;
-                    logMessage(
-                        'error',
-                        `Error when uploading file ${chalk.magenta(asset)}. Error: ${sendFileResult.message}`,
-                        true
-                    );
-                } else {
-                    successAssets++;
-                    logMessage('success', `File ${chalk.magenta(asset)} uploaded.`, true);
+                    logMessage('error', `File extension not allowed (${chalk.magenta(asset)})`, true);
                 }
             }
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -5,7 +5,7 @@ import { readFileSync } from 'fs';
 import { isBinaryFileSync } from 'isbinaryfile';
 import { program } from 'commander';
 import { TrayApi } from '../api/v1/TrayApi';
-import { loadConfigFile, logMessage } from '../libs/utils';
+import { loadConfigFile, logMessage, checkFileUploadPermission } from '../libs/utils';
 
 export function watch() {
     program.command('watch').action(async () => {
@@ -57,23 +57,30 @@ export function watch() {
             .on('change', async (path) => {
                 const asset = slash(path);
 
-                const assetStartingWithSlash = asset.startsWith('/') ? asset : `/${asset}`;
+                const isAllowed = checkFileUploadPermission(asset);
 
-                const fileContent = readFileSync(`.${assetStartingWithSlash}`);
-                const isBinary = isBinaryFileSync(`.${assetStartingWithSlash}`);
+                if ( isAllowed ) {
+                    const assetStartingWithSlash = asset.startsWith('/') ? asset : `/${asset}`;
 
-                logMessage('pending', `Uploading file ${chalk.magenta(asset)}...`);
+                    const fileContent = readFileSync(`.${assetStartingWithSlash}`);
+                    const isBinary = isBinaryFileSync(`.${assetStartingWithSlash}`);
 
-                const sendFileResult: any = await api.sendThemeAsset(assetStartingWithSlash, fileContent, isBinary);
+                    logMessage('pending', `Uploading file ${chalk.magenta(asset)}...`);
 
-                if (!sendFileResult.success) {
-                    logMessage(
-                        'error',
-                        `Error when uploading file ${chalk.magenta(asset)}. Error: ${sendFileResult.message}`,
-                        true
-                    );
-                } else {
-                    logMessage('success', `File ${chalk.magenta(asset)} uploaded`, true);
+                    const sendFileResult: any = await api.sendThemeAsset(assetStartingWithSlash, fileContent, isBinary);
+
+                    if (!sendFileResult.success) {
+                        logMessage(
+                            'error',
+                            `Error when uploading file ${chalk.magenta(asset)}. Error: ${sendFileResult.message}`,
+                            true
+                        );
+                    } else {
+                        logMessage('success', `File ${chalk.magenta(asset)} uploaded`, true);
+                    }                    
+                }
+                else {
+                    logMessage('error', `File extension not allowed (${chalk.magenta(asset)})`, true);
                 }
             })
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -127,3 +127,32 @@ export function logMessage(type: LogMessageType, message: string, done: boolean 
         log.done();
     }
 }
+
+export function checkFileUploadPermission (filename: string) {
+    const allowedExtensions = [
+        '.css',
+        '.eot',
+        '.gif',
+        '.html',
+        '.jpeg',
+        '.jpg',
+        '.js',
+        '.json',
+        '.png',
+        '.svg',
+        '.ttf',
+        '.woff',
+        '.woff2'
+    ];
+
+    let allowed = false;
+
+    allowedExtensions.forEach( (extension) => {
+        if (filename.endsWith(extension)) {
+            allowed = true;
+            return;
+        }
+    })
+
+    return allowed;
+}

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { isBinaryFileSync } from 'isbinaryfile';
 import { readFile, writeFile } from 'fs/promises';
 import { dirname } from 'path';
 
@@ -155,4 +156,16 @@ export function checkFileUploadPermission (filename: string) {
     })
 
     return allowed;
+}
+
+export function prepareToUpload (filename: string) {
+    const assetStartingWithSlash = filename.startsWith('/') ? filename : `/${filename}`;
+    const fileContent = readFileSync(`.${assetStartingWithSlash}`);
+    const isBinary = isBinaryFileSync(`.${assetStartingWithSlash}`);
+
+    return {
+        assetStartingWithSlash: assetStartingWithSlash,
+        fileContent: fileContent,
+        isBinary: isBinary
+    }
 }


### PR DESCRIPTION
Relacionado a esta issue: https://github.com/rhandrade/tray-theme/issues/10 
Não considero isso pronto, mas sim uma oportunidade para avaliar os caminhos abordados.

#O que fiz aqui?

- Abstraí uma função para verificar se o arquivo pode ser subido ou não. Hoje, apenas verifica a extensão do arquivo, mas esta função poderá ser melhorada para ignorar padrões de pasta (como a `node_modules`, que hoje ele tenta subir)
- Abstraí uma função para preparar os parâmetros para envio de arquivos pela API
- Usei essas funções no `watch` mas também no `upload`, padronizando ambos.

Gostaria que avaliassem aqui para ver se devo seguir no caminho. Se quiserem já fazer merge, também já podem se beneficiar dessa pequena melhoria.