### PR TITLE
Folder uploads and upload core

### DIFF
--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -24,7 +24,7 @@ export function upload() {
                     `Either choose between ${chalk.magenta('upload -c|--core')} or ${chalk.magenta('upload [files...]')}`,
                     true
                 );
-                return false;           
+                process.exit();         
             }
 
             // Uploads only "core" files

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -13,9 +13,32 @@ import { dirname, extname } from 'path';
 export function upload() {
     program
         .command('upload')
+        .option('-c, --core')
         .arguments('[files...]')
         .action(async (files: string[], options) => {
             let assets = files;
+
+            if ( options.core && assets.length ) {
+                logMessage(
+                    'error',
+                    `Either choose between ${chalk.magenta('upload -c|--core')} or ${chalk.magenta('upload [files...]')}`,
+                    true
+                );
+                return false;           
+            }
+
+            // Uploads only "core" files
+            if ( options.core ) {
+                assets = [
+                    'configs/settings.html', // Does not include settings.json to avoid ovewriting live test data
+                    'css/**/*',
+                    'elements/**/*',
+                    'js/**/*',
+                    'layouts/**/*',
+                    'pages/**/*'
+                ]
+            }
+
             let globbedAssets = [];
 
             // If no argument is provided, globs the whole folder


### PR DESCRIPTION
Este PR lida com estas duas issues: https://github.com/rhandrade/tray-theme/issues/17 e https://github.com/rhandrade/tray-theme/issues/21, pois ambas são bastante interligadas.

Removi o filtro que excluía o `config.yml` porque, em conjunto com o este outro PR https://github.com/rhandrade/tray-theme/pull/16, ele será obsoleto.